### PR TITLE
utils_ppser.f90 to the lib

### DIFF
--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(
     SOURCES
     "m_serialize.f90"
+    "utils_ppser.f90"
 )
 
 add_library(fortranser_files OBJECT ${SOURCES})


### PR DESCRIPTION
Add `utils_ppser.f90` to the `FortranSer`library. Needed at compile (`.mod` file) and link time.
