### PR TITLE
Python serializer can register fields with non-zero halo

### DIFF
--- a/python/serialbox/serialization.py
+++ b/python/serialbox/serialization.py
@@ -407,7 +407,9 @@ class serializer(object):
         return field
 
     def save_field(self, name, field, savepoint):
-        self.register_field(name, field)
+        if name not in self.fieldnames:
+            self.register_field(name, field)
+
         name, namelength = extract_string(name)
 
         # Extract strides
@@ -416,15 +418,28 @@ class serializer(object):
         fs_write_field(self.serializer, savepoint.savepoint, name, namelength,
                 field.ctypes.data, strides[0], strides[1], strides[2], strides[3])
 
-    def register_field(self, name, field):
+    def register_field(self, name, field, **kwargs):
         name, namelength = extract_string(name)
         dtype, dtypelength = extract_string(field.dtype.name)
         size = [field.shape[i] if i < len(field.shape) else 1 for i in range(4)]
 
+        # Extract halo
+        iminushalo = kwargs.get('iminushalo', 0)
+        iplushalo = kwargs.get('iplushalo', 0)
+        jminushalo = kwargs.get('jminushalo', 0)
+        jplushalo = kwargs.get('jplushalo', 0)
+        kminushalo = kwargs.get('kminushalo', 0)
+        kplushalo = kwargs.get('kplushalo', 0)
+        lminushalo = kwargs.get('lminushalo', 0)
+        lplushalo = kwargs.get('lplushalo', 0)
+
+        # Call C routine
         fs_register_field(self.serializer, name, namelength,
                 dtype, dtypelength, field.dtype.itemsize,
                 size[0], size[1], size[2], size[3],
-                0, 0, 0, 0, 0, 0, 0, 0)
+                iminushalo, iplushalo, jminushalo, jplushalo,
+                kminushalo, kplushalo, lminushalo, lplushalo
+                )
 
     @property
     def fieldnames(self):
@@ -432,10 +447,11 @@ class serializer(object):
         n_fields = fs_fields(self.serializer)
         name_lengths = (ctypes.c_int*n_fields)()
         fs_fieldname_lengths(self.serializer, name_lengths)
+        name_length = max(name_lengths)
 
         # Get field names
         names = ((ctypes.c_char_p)*n_fields)()
-        names[:] = [('\0'*name_lengths[i]).encode() for i in range(n_fields)]
+        names[:] = [('\0'*name_length).encode() for i in range(n_fields)]
         fs_get_fieldnames(self.serializer, names)
 
         return [n.decode() for n in names]

--- a/python/serialbox/serialization.py
+++ b/python/serialbox/serialization.py
@@ -447,7 +447,7 @@ class serializer(object):
         n_fields = fs_fields(self.serializer)
         name_lengths = (ctypes.c_int*n_fields)()
         fs_fieldname_lengths(self.serializer, name_lengths)
-        name_length = max(name_lengths)
+        name_length = max(name_lengths)+1
 
         # Get field names
         names = ((ctypes.c_char_p)*n_fields)()

--- a/python/serialbox/serialization.py
+++ b/python/serialbox/serialization.py
@@ -52,7 +52,9 @@ def type2dtype(typestr, typesize):
         'int4' : np.int32,
         'int8' : np.int64,
         'float4' : np.float32,
-        'double8' : np.float64
+        'float324' : np.float32,
+        'double8' : np.float64,
+        'float648' : np.float64
         }
     try:
         return conv["{0}{1}".format(typestr,typesize)]


### PR DESCRIPTION
This change allows to register fields with a non-trivial halo from the python interface. The halo specification can be passed as keyword argument to register_field. If nothing is passed, zero-halo is assumed.

This commit also fixes a bug in the function which receives the file names. Now enough memory is reserved to store the name of all fields.

The `save_field` function now registers the field only if such a field is not yet registered.
