### PR TITLE
Fix fortran library compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Makefile
+cmake_install.cmake
+install_manifest.txt
+*.a
+*.mod
+*.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ SET(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install/" CACHE PATH "installation
 project( SerialBox )
 enable_language (Fortran)
 find_package( Boost )
-include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
+#include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
 
 set(ENABLE_DOC "OFF" CACHE BOOL "enable building doc" )
 if(ENABLE_DOC)
@@ -65,10 +65,10 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif ()
 
 # Serialization
-include_directories( SYSTEM libs/libjson )
-include_directories( libs/sha256 )
-include_directories( libs/gmock-gtest)
-include_directories( src)
+#include_directories( SYSTEM libs/libjson )
+#include_directories( libs/sha256 )
+#include_directories( libs/gmock-gtest)
+#include_directories( src)
 
 
 # Python installation path 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ SET(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install/" CACHE PATH "installation
 project( SerialBox )
 enable_language (Fortran)
 find_package( Boost )
-#include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
 
 set(ENABLE_DOC "OFF" CACHE BOOL "enable building doc" )
 if(ENABLE_DOC)
@@ -63,13 +62,6 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
     set(CMAKE_MACOSX_RPATH "${CMAKE_INSTALL_RPATH}")
 endif ()
-
-# Serialization
-#include_directories( SYSTEM libs/libjson )
-#include_directories( libs/sha256 )
-#include_directories( libs/gmock-gtest)
-#include_directories( src)
-
 
 # Python installation path 
 set (PYTHON_PATH "python")

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -1,10 +1,10 @@
+
+SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp ")
 set(
     SOURCES
     "m_serialize.f90"
     "utils_ppser.f90"
 )
-
-add_library(fortranser_files OBJECT ${SOURCES})
 
 add_library(
     FortranSer STATIC ${SOURCES}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,11 @@
+include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
+
+# Serialization
+include_directories( SYSTEM ${CMAKE_SOURCE_DIR}/libs/libjson )
+include_directories( ${CMAKE_SOURCE_DIR}/libs/sha256 )
+include_directories( ${CMAKE_SOURCE_DIR}/libs/gmock-gtest)
+include_directories( ${CMAKE_SOURCE_DIR}/src)
+
 add_subdirectory( utils )
 add_subdirectory( serializer )
 add_subdirectory( wrapper )

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+include_directories( SYSTEM ${CMAKE_SOURCE_DIR}/libs/libjson )
+include_directories( ${CMAKE_SOURCE_DIR}/src)
 
 add_executable(
     dump

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,2 +1,7 @@
+
+include_directories( SYSTEM ${CMAKE_SOURCE_DIR}/libs/libjson )
+include_directories( ${CMAKE_SOURCE_DIR}/src)
+include_directories( ${CMAKE_SOURCE_DIR}/libs/gmock-gtest)
+
 add_subdirectory(serializer)
 add_subdirectory(wrapper)


### PR DESCRIPTION
With @pallaskat, we discover that the source of my problem with serialbox from fortran were a wrong compilation of the Fortran library. 

I moved the `include_directories`statement were they are really needed. Like this, they are not passed to the Fortran compiler during the compilation of the library. 

I have a small Fortran example that I can put on the repo with its own CMake. Should I put it @cosunae @andyspiros @pspoerri ? Is so, I'll do a PR with it after this one is merged (hopefully)
