### PR TITLE
Don't require libjson headers to #include Serialbox

### DIFF
--- a/libs/libjson/CMakeLists.txt
+++ b/libs/libjson/CMakeLists.txt
@@ -1,38 +1,5 @@
 # ADDING JSON
 
-set ( JSON_HEADERS
-"libjson.h"
-"JSONOptions.h"
-)
-
-set ( JSON_INTERNAL_HEADERS
-"_internal/Source/internalJSONNode.h"
-"_internal/Source/JSONAllocator.h"
-"_internal/Source/JSON_Base64.h"
-"_internal/Source/JSONChildren.h"
-"_internal/Source/JSONDebug.h"
-"_internal/Source/JSONDefs.h"
-"_internal/Source/JSONGlobals.h"
-"_internal/Source/JSONMemory.h"
-"_internal/Source/JSONMemoryPool.h"
-"_internal/Source/JSONNode.h"
-"_internal/Source/JSONPreparse.h"
-"_internal/Source/JSONSharedString.h"
-"_internal/Source/JSONSingleton.h"
-"_internal/Source/JSONStats.h"
-"_internal/Source/JSONStream.h"
-"_internal/Source/JSONValidator.h"
-"_internal/Source/JSONWorker.h"
-"_internal/Source/NumberToString.h"
-)
-
-set (JSON_DEFS_HEADERS
-"_internal/Source/JSONDefs/GNU_C.h"
-"_internal/Source/JSONDefs/Strings_Defs.h"
-"_internal/Source/JSONDefs/Unknown_C.h"
-"_internal/Source/JSONDefs/Visual_C.h"
-)
-
 set( JSON_SOURCES
 "_internal/Source/internalJSONNode.cpp"
 "_internal/Source/JSONAllocator.cpp"
@@ -50,13 +17,9 @@ set( JSON_SOURCES
 "_internal/Source/libjson.cpp"
 )
 
-# generatring the library called libjson 
-
-add_library(json_files OBJECT ${JSON_HEADERS} ${JSON_INTERNAL_HEADERS} ${JSON_DEFS_HEADERS} ${JSON_SOURCES} )
+# generatring the library called libjson
+add_library(json_files OBJECT ${JSON_SOURCES} )
 add_library(json $<TARGET_OBJECTS:json_files>)
 
 install( TARGETS json DESTINATION lib/ )
-install (FILES ${JSON_HEADERS} DESTINATION "include/STELLA/libjson")
-install (FILES ${JSON_INTERNAL_HEADERS} DESTINATION "include/STELLA/libjson/_internal/Source")
-install (FILES ${JSON_DEFS_HEADERS} DESTINATION "include/STELLA/libjson/_internal/Source/JSONDefs")
 

--- a/libs/libjson/CMakeLists.txt
+++ b/libs/libjson/CMakeLists.txt
@@ -1,5 +1,38 @@
 # ADDING JSON
 
+set ( JSON_HEADERS
+"libjson.h"
+"JSONOptions.h"
+)
+
+set ( JSON_INTERNAL_HEADERS
+"_internal/Source/internalJSONNode.h"
+"_internal/Source/JSONAllocator.h"
+"_internal/Source/JSON_Base64.h"
+"_internal/Source/JSONChildren.h"
+"_internal/Source/JSONDebug.h"
+"_internal/Source/JSONDefs.h"
+"_internal/Source/JSONGlobals.h"
+"_internal/Source/JSONMemory.h"
+"_internal/Source/JSONMemoryPool.h"
+"_internal/Source/JSONNode.h"
+"_internal/Source/JSONPreparse.h"
+"_internal/Source/JSONSharedString.h"
+"_internal/Source/JSONSingleton.h"
+"_internal/Source/JSONStats.h"
+"_internal/Source/JSONStream.h"
+"_internal/Source/JSONValidator.h"
+"_internal/Source/JSONWorker.h"
+"_internal/Source/NumberToString.h"
+)
+
+set (JSON_DEFS_HEADERS
+"_internal/Source/JSONDefs/GNU_C.h"
+"_internal/Source/JSONDefs/Strings_Defs.h"
+"_internal/Source/JSONDefs/Unknown_C.h"
+"_internal/Source/JSONDefs/Visual_C.h"
+)
+
 set( JSON_SOURCES
 "_internal/Source/internalJSONNode.cpp"
 "_internal/Source/JSONAllocator.cpp"
@@ -17,9 +50,13 @@ set( JSON_SOURCES
 "_internal/Source/libjson.cpp"
 )
 
-# generatring the library called libjson
-add_library(json_files OBJECT ${JSON_SOURCES} )
+# generatring the library called libjson 
+
+add_library(json_files OBJECT ${JSON_HEADERS} ${JSON_INTERNAL_HEADERS} ${JSON_DEFS_HEADERS} ${JSON_SOURCES} )
 add_library(json $<TARGET_OBJECTS:json_files>)
 
 install( TARGETS json DESTINATION lib/ )
+install (FILES ${JSON_HEADERS} DESTINATION "include/STELLA/libjson")
+install (FILES ${JSON_INTERNAL_HEADERS} DESTINATION "include/STELLA/libjson/_internal/Source")
+install (FILES ${JSON_DEFS_HEADERS} DESTINATION "include/STELLA/libjson/_internal/Source/JSONDefs")
 

--- a/src/serializer/CentralizedFileFormat.h
+++ b/src/serializer/CentralizedFileFormat.h
@@ -2,8 +2,9 @@
 //This file is released under terms of BSD license`
 //See LICENSE.txt for more information
 
-#include "libjson.h"
 #include "FileFormat.h"
+
+class JSONNode;
 
 namespace ser {
 
@@ -56,3 +57,4 @@ namespace ser {
     };
 
 } // namespace ser
+

--- a/src/serializer/DataFieldInfo.h
+++ b/src/serializer/DataFieldInfo.h
@@ -11,7 +11,8 @@
 #include "TypeName.h"
 #include "IJKBoundary.h"
 #include "IJKSize.h"
-#include "libjson.h"
+
+class JSONNode;
 
 namespace ser {
     class DataFieldInfo
@@ -478,3 +479,4 @@ namespace ser {
     };
 
 } // namespace ser
+

--- a/src/serializer/FieldsTable.h
+++ b/src/serializer/FieldsTable.h
@@ -5,8 +5,9 @@
 
 #include <map>
 #include <string>
-#include "libjson.h"
 #include "DataFieldInfo.h"
+
+class JSONNode;
 
 namespace ser {
 
@@ -139,3 +140,4 @@ namespace ser {
     };
 
 } //namespace ser
+

--- a/src/serializer/MetainfoSet.h
+++ b/src/serializer/MetainfoSet.h
@@ -12,8 +12,8 @@
 #include "boost/type_traits/is_same.hpp"
 
 #include "SerializationException.h"
-#include "libjson.h"
 
+class JSONNode;
 
 namespace ser {
 

--- a/src/serializer/Savepoint.h
+++ b/src/serializer/Savepoint.h
@@ -5,7 +5,8 @@
 
 #include <string>
 #include "MetainfoSet.h"
-#include "libjson.h"
+
+class JSONNode;
 
 namespace ser {
 


### PR DESCRIPTION
This change makes the life easier for Serialbox users: libjson headers are no more installed and the user does not have to put the libjson headers directory accessible to the compiler.

Now libjson is really just an internally-used library only (except the user has to link against `libjson.a` until we have a shared library available for everyone...).

I converted `#include "libjson.h"` into forward declarations of `JSONNode`.

I tested the unittests on my machines, and the python library, and they seem to work perfectly.
