### PR TITLE
Fix serialbox case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required( VERSION 2.8 )
 # able to change.
 SET(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install/" CACHE PATH "installation prefix")
 
-project( SerialBox )
+project( Serialbox )
 enable_language (Fortran)
 find_package( Boost )
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+# Next release
+ * SerialBox changed to Serialbox everywhere
+
 # Release 0.1.1
  * Bug fix for BOOST_STATIC_ASSERT
  

--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@
 
 # Introduction
 
-The SerialBox is a set of tools around serialization / deserialization of data. 
+The Serialbox is a set of tools around serialization / deserialization of data. 
 The box is used in several projects for building validation frameworks against reference runs.
 This is useful in the scope of rewrite of large codes, or when porting codes to multiple computing architectures. 
 As an example, porting scientific codes to graphical processing units, that require continuous validation against the existing x86 code.
 
 # Structure
 
-* src/ : It the main core of the SerialBox, written in C++, which provides
+* src/ : It the main core of the Serialbox, written in C++, which provides
   * C++ functionality that can be used to serialize data from a reference run. 
   * Interfaces for deserializing into memory data structures
   * Control the metadata of the fields being serialized/deserialized. 
   * src/utils: logger and other C++ utilities
   * wrapper: a C wrapper that allows to interoperate the core C++ functionality from other languages like Fortran
 * doc/ : latex documentation, tutorials and presentations
-* [python/](python/README.md) : contains various python tools based on the SerialBox format, namely
-  * pp_ser: a tiny DSL/parser that facilitates inserting SerialBox statements into your Fortran Code. 
+* [python/](python/README.md) : contains various python tools based on the Serialbox format, namely
+  * pp_ser: a tiny DSL/parser that facilitates inserting Serialbox statements into your Fortran Code. 
   * Visualizer: a python tool that helps visualizing serialized data
 * tools/ : various tools used to validation, dumping, converting or comparing of multiple serialized runs, etc. 
-* fortran/ : fortran interfaces to the SerialBox C++ functionality
+* fortran/ : fortran interfaces to the Serialbox C++ functionality
  
 # Building
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,18 +1,18 @@
-# SerialBox Python Tools
+# Serialbox Python Tools
 
-This folder contains the SerialBox python tools. 
+This folder contains the Serialbox python tools. 
 
-- `pp_ser.py` - the SerialBox preproccessor to add the serialization directives to a Fortran program. For documentation see the docs folder. 
-- `serialbox` - the SerialBox python module that allows de-serializing and visualizing data stored by SerialBox
+- `pp_ser.py` - the Serialbox preproccessor to add the serialization directives to a Fortran program. For documentation see the docs folder. 
+- `serialbox` - the Serialbox python module that allows de-serializing and visualizing data stored by Serialbox
 - `test.py` - the unittests for the Python Tools
 
 ## The `serialbox` Python Module
 
-The serialbox python module makes use of the C++ SerialBox wrapper to read serialized data written by SerialBox. For convenience the required dynamic library is distributed with an installation of SerialBox. 
+The serialbox python module makes use of the C++ Serialbox wrapper to read serialized data written by Serialbox. For convenience the required dynamic library is distributed with an installation of Serialbox. 
 
 ### Installation
 
-Build SerialBox as per the installation and building instructions. CMake installs the serialbox module to 
+Build Serialbox as per the installation and building instructions. CMake installs the serialbox module to 
 `$CMAKE_INSTALL_PREFIX/python/serialbox` with `make install` in the build directory.
 
 To use the serialbox python module either

--- a/python/serialbox/serialization.py
+++ b/python/serialbox/serialization.py
@@ -32,7 +32,7 @@ for d in dirs:
 
     # OS X
 
-    libfile = pjoin(d, 'libSerialBox_Wrapper.'+library_postfix)
+    libfile = pjoin(d, 'libSerialbox_Wrapper.'+library_postfix)
     try:
         wrapper_try = ctypes.cdll.LoadLibrary(libfile)
         if wrapper_try is not None:

--- a/src/serializer/CMakeLists.txt
+++ b/src/serializer/CMakeLists.txt
@@ -36,9 +36,9 @@ set(
 add_library(serialbox_files OBJECT ${GENERIC_SOURCES} ${GENERIC_HEADERS})
 
 add_library(
-    SerialBox STATIC ${GENERIC_SOURCES}
+    Serialbox STATIC ${GENERIC_SOURCES}
 )
-install (TARGETS SerialBox DESTINATION "lib")
+install (TARGETS Serialbox DESTINATION "lib")
 
 # Install headers
-install (FILES ${GENERIC_HEADERS} DESTINATION "include/SerialBox")
+install (FILES ${GENERIC_HEADERS} DESTINATION "include/Serialbox")

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -19,4 +19,4 @@ add_library(
 install (TARGETS Utils DESTINATION "lib")
 
 # Install headers
-install (FILES ${GENERIC_HEADERS} DESTINATION "include/SerialBox")
+install (FILES ${GENERIC_HEADERS} DESTINATION "include/Serialbox")

--- a/src/wrapper/CMakeLists.txt
+++ b/src/wrapper/CMakeLists.txt
@@ -8,20 +8,20 @@ add_library(serialbox_wrapper_files OBJECT ${SOURCES})
 
 
 add_library(
-    SerialBoxWrapper STATIC
+    SerialboxWrapper STATIC
     ${SOURCES}
 )
-target_link_libraries( SerialBoxWrapper SerialBox Utils json sha256 )
-install( TARGETS SerialBoxWrapper DESTINATION lib/ )
+target_link_libraries( SerialboxWrapper Serialbox Utils json sha256 )
+install( TARGETS SerialboxWrapper DESTINATION lib/ )
 
-add_library(SerialBox_Wrapper SHARED
+add_library(Serialbox_Wrapper SHARED
     $<TARGET_OBJECTS:json_files>
     $<TARGET_OBJECTS:sha256_files>
     $<TARGET_OBJECTS:utils_files>
     $<TARGET_OBJECTS:serialbox_files>
     $<TARGET_OBJECTS:serialbox_wrapper_files>
 )
-install(TARGETS SerialBoxWrapper DESTINATION "lib")
+install(TARGETS SerialboxWrapper DESTINATION "lib")
 
 # The python library expects a serialbox dynamic library distributed with itself.
-install(TARGETS SerialBox_Wrapper DESTINATION ${PYTHON_PATH}/serialbox/)
+install(TARGETS Serialbox_Wrapper DESTINATION ${PYTHON_PATH}/serialbox/)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -17,9 +17,9 @@ add_executable(
 set_target_properties(
     compare PROPERTIES COMPILE_FLAGS "${CXX11_FLAGS}"
 )
-target_link_libraries( compare SerialBox Utils json sha256)
+target_link_libraries( compare Serialbox Utils json sha256)
 
-target_link_libraries( dump SerialBox Utils json sha256)
+target_link_libraries( dump Serialbox Utils json sha256)
 
 install(TARGETS compare DESTINATION "bin")
 install(TARGETS dump DESTINATION "bin")

--- a/unittest/serializer/CMakeLists.txt
+++ b/unittest/serializer/CMakeLists.txt
@@ -14,6 +14,6 @@ add_executable(
 )
 
 serialbox_add_test(SerializerUnittest)
-target_link_libraries( SerializerUnittest gmock-gtest SerialBox json sha256 Utils )
+target_link_libraries( SerializerUnittest gmock-gtest Serialbox json sha256 Utils )
 install( TARGETS SerializerUnittest DESTINATION bin/ )
 

--- a/unittest/wrapper/CMakeLists.txt
+++ b/unittest/wrapper/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(
     WrapperUnittest
     ${SOURCES}
 )
-target_link_libraries( WrapperUnittest SerialBoxWrapper gmock-gtest SerialBoxWrapper SerialBox SerialBoxWrapper json sha256 Utils )
+target_link_libraries( WrapperUnittest SerialboxWrapper gmock-gtest SerialboxWrapper Serialbox SerialboxWrapper json sha256 Utils )
 install( TARGETS WrapperUnittest DESTINATION bin/ )
 serialbox_add_test(WrapperUnittest)
 


### PR DESCRIPTION
We still have some cases where Serialbox is written SerialBox. We should be consistent, so I changed these instances with Serialbox everywhere.
