### PR TITLE
Handle MPI rank in the fortran lib

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 # Next release
  * SerialBox changed to Serialbox everywhere
+ * Handle execution with multiple MPI processes with an mpi_rank option for
+ the !$ser init directive
 
 # Release 0.1.1
  * Bug fix for BOOST_STATIC_ASSERT

--- a/doc/pp_ser/ppser_doc.tex
+++ b/doc/pp_ser/ppser_doc.tex
@@ -61,7 +61,7 @@ $ ./pp_ser.py -d . --no-prefix
 Initialize the serialization framework.
 
 \begin{lstlisting}
-!$ser init directory=dir prefix=pre [mode=] [prefix_ref=] [if if_statement]
+!$ser init directory=dir prefix=pre [mode=] [prefix_ref=] [mpi_rank=] [if if_statement]
 \end{lstlisting}
 
 \begin{itemize}
@@ -69,12 +69,13 @@ Initialize the serialization framework.
 \item \texttt{prefix}: the prefix of the main database file names
 \item \texttt{mode}: 0 or 1
 \item \texttt{prefix\_ref}: the prefix of the reference database file names. If reference database is set, the serializer reads from the reference database and writes to the main database.
+\item \texttt{mpi\_rank}: the MPI rank (optional). If the MPI rank is set, database files will be suffixed with it. 
 \item \texttt{if\_statement}: under which condition is the directive executed
 \end{itemize}
 
 Examples:
 \begin{lstlisting}
-!$ser init directory='.' prefix='Field'
+!$ser init directory='.' prefix='Field' mpi_rank=my_cart_id
 !$ser init directory='.' prefix='database' prefix_ref='ref_database'
 !$ser init directory='.' prefix='Field' if ser_test_mode==0
 \end{lstlisting}
@@ -281,23 +282,5 @@ END module mo_cuadjust
 
 If \texttt{ser\_test\_mode} is 0, we are generating the reference database. If it is 1, we are generating the test database.
 
-\subsection{Multiple MPI nodes}
-When we are running on multiple MPI nodes, we do not want the serializer to write to the same database. To solve this, we add the MPI rank to the prefix of the database.
-\begin{lstlisting}
-MODULE mo_cuadjust
-  !$ser verbatim USE mo_mpi,        ONLY: get_my_global_mpi_id
-  IMPLICIT NONE
-SUBROUTINE cuadjtq()
-!get mpi rank
-    !$ser verbatim mpi_id = get_my_global_mpi_id()
-    !$ser verbatim Write( str_prefix, '(I1)' ) mpi_id
-    !$ser verbatim str_prefix = 'rank'//trim(str_prefix)//'_field'
-
-!initialize the serialization framework
-    !$ser init directory='.' prefix='ref_'//str_prefix
-
-END SUBROUTINE cuadjtq
-END module mo_cuadjust
-\end{lstlisting}
 
 \end{document}

--- a/fortran/utils_ppser.f90
+++ b/fortran/utils_ppser.f90
@@ -58,17 +58,13 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank)
   INTEGER                          :: intvalue
   INTEGER, OPTIONAL, INTENT(IN)    :: mpi_rank
   CHARACTER(LEN=1), DIMENSION(128) :: buffer
-  CHARACTER(LEN=7)                 :: suffix
+  CHARACTER(LEN=15)                 :: suffix
 
   ! Initialize serializer and savepoint
   IF ( .NOT. ppser_initialized ) THEN
     IF ( present(mpi_rank) ) THEN
-      IF (mpi_rank < 10) THEN
-        WRITE(suffix, '(A5,I1)') "_rank", mpi_rank
-      ELSE
-        WRITE(suffix, '(A5,I2)') "_rank", mpi_rank
-      END IF
-    END IF
+      WRITE(suffix, '(A5,I0)') "_rank", mpi_rank
+   END IF
     CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer)
     CALL fs_create_savepoint('', ppser_savepoint)
     IF ( PRESENT(mode) ) ppser_mode = mode

--- a/fortran/utils_ppser.f90
+++ b/fortran/utils_ppser.f90
@@ -50,26 +50,30 @@ CONTAINS
 
 !============================================================================
 
-SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref)
+SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank)
   CHARACTER(LEN=*), INTENT(IN)     :: directory, prefix
   INTEGER, OPTIONAL, INTENT(IN)    :: mode
   CHARACTER(LEN=*), OPTIONAL, INTENT(IN)     :: prefix_ref
   REAL                             :: realvalue
   INTEGER                          :: intvalue
+  INTEGER, OPTIONAL, INTENT(IN)    :: mpi_rank
   CHARACTER(LEN=1), DIMENSION(128) :: buffer
-  CHARACTER(LEN=6)                 :: suffix
+  CHARACTER(LEN=7)                 :: suffix
 
   ! Initialize serializer and savepoint
   IF ( .NOT. ppser_initialized ) THEN
-    ! IF (mode == 0) THEN
-      CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer)
-    ! ELSE
-    !   CALL fs_create_serializer(directory, TRIM(prefix), 'a', ppser_serializer)
-    ! ENDIF
+    IF ( present(mpi_rank) ) THEN
+      IF (mpi_rank < 10) THEN
+        WRITE(suffix, '(A5,I1)') "_rank", mpi_rank
+      ELSE
+        WRITE(suffix, '(A5,I2)') "_rank", mpi_rank
+      END IF
+    END IF
+    CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer)
     CALL fs_create_savepoint('', ppser_savepoint)
     IF ( PRESENT(mode) ) ppser_mode = mode
     IF ( PRESENT(prefix_ref) ) THEN
-      CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref)
+      CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref)
     ENDIF
   ENDIF
   ppser_initialized = .TRUE.


### PR DESCRIPTION
Add an option to `!$ser init` to pass the MPI rank of the process instead of dealing with concatenation and so on by the user. 

Example in cosmo

``` Fortran
!$ser init directory='.' prefix='Field' mpi_rank=my_cart_id
```

A suffix is applied to the `prefix` directly in `utils_ppser.f90`

`pp_ser.py` does not require any changes as it can handle 
