### PR TITLE
Avoid adding suffix if there is no need

### DIFF
--- a/fortran/utils_ppser.f90
+++ b/fortran/utils_ppser.f90
@@ -58,20 +58,26 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank)
   INTEGER                          :: intvalue
   INTEGER, OPTIONAL, INTENT(IN)    :: mpi_rank
   CHARACTER(LEN=1), DIMENSION(128) :: buffer
-  CHARACTER(LEN=15)                 :: suffix
+  CHARACTER(LEN=15)                :: suffix
 
   ! Initialize serializer and savepoint
   IF ( .NOT. ppser_initialized ) THEN
     IF ( present(mpi_rank) ) THEN
       WRITE(suffix, '(A5,I0)') "_rank", mpi_rank
-   END IF
-    CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer)
+      CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer)
+    ELSE 
+      CALL fs_create_serializer(directory, TRIM(prefix), 'w', ppser_serializer)
+    END IF
     CALL fs_create_savepoint('', ppser_savepoint)
     IF ( PRESENT(mode) ) ppser_mode = mode
     IF ( PRESENT(prefix_ref) ) THEN
-      CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref)
-    ENDIF
-  ENDIF
+      IF ( PRESENT(mpi_rank) ) THEN 
+        CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref)
+      ELSE
+        CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref)
+      END IF
+    END IF
+  END IF
   ppser_initialized = .TRUE.
 
   ! Get data size

--- a/fortran/utils_ppser.f90
+++ b/fortran/utils_ppser.f90
@@ -62,7 +62,7 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank)
 
   ! Initialize serializer and savepoint
   IF ( .NOT. ppser_initialized ) THEN
-    IF ( present(mpi_rank) ) THEN
+    IF ( PRESENT(mpi_rank) ) THEN
       WRITE(suffix, '(A5,I0)') "_rank", mpi_rank
       CALL fs_create_serializer(directory, TRIM(prefix)//TRIM(suffix), 'w', ppser_serializer)
     ELSE 


### PR DESCRIPTION
- Do not add suffix to the prefix if mpi_rank is not present 
- Unify style 
