### PR TITLE
Add a new message if the source of the error is NaN

### DIFF
--- a/tools/compare.cpp
+++ b/tools/compare.cpp
@@ -150,7 +150,7 @@ void printDifference(const Serializer& serializer1, const Serializer& serializer
 
 	std::cout << " | Number of values: " << std::setw(6) << nValues << "\n";
 	std::cout << " | Number of errors: " << std::setw(6) << nErrors << "\n";
-	if (nNan > 0) std::cout << " | Number of Nan errors: " << std::setw(6) << nNan << "\n";
+	if (nNan > 0) std::cout << " | Number of NaN errors: " << std::setw(6) << nNan << "\n";
 	std::cout << " | Percentuage of errors: " << std::setprecision(2) << std::fixed << (100.*nErrors) / nValues << " %\n";
 	std::cout << " | Maximum absolute error: " << std::setw(17) << std::setfill(' ') << std::scientific << std::setprecision(10) << maxAbsError  << "\n";
 	std::cout << " | Maximum relative error: " << std::setw(17) << std::setfill(' ') << std::scientific << std::setprecision(10) << maxRelError  << "\n";

--- a/tools/compare.cpp
+++ b/tools/compare.cpp
@@ -124,7 +124,7 @@ void printDifference(const Serializer& serializer1, const Serializer& serializer
 	int nValues = (bounds.iUpper - bounds.iLower + 1) * (bounds.jUpper - bounds.jLower + 1) *
 	              (bounds.kUpper - bounds.kLower + 1) * (bounds.lUpper - bounds.lLower + 1);
 	int nErrors = 0;
-	int nNan = 0;
+	unsigned int nNan = 0;
 
 	double maxRelError = 0;
 	double maxAbsError = 0;

--- a/tools/compare.cpp
+++ b/tools/compare.cpp
@@ -124,6 +124,8 @@ void printDifference(const Serializer& serializer1, const Serializer& serializer
 	int nValues = (bounds.iUpper - bounds.iLower + 1) * (bounds.jUpper - bounds.jLower + 1) *
 	              (bounds.kUpper - bounds.kLower + 1) * (bounds.lUpper - bounds.lLower + 1);
 	int nErrors = 0;
+	int nNan = 0;
+
 	double maxRelError = 0;
 	double maxAbsError = 0;
 
@@ -139,6 +141,8 @@ void printDifference(const Serializer& serializer1, const Serializer& serializer
 
 						const double val = static_cast<double>(data1[index]);
 						const double ref = static_cast<double>(data2[index]);
+
+						if ((val != val) || (ref != ref)) ++nNan;
 						maxAbsError = std::max(maxAbsError, std::fabs(val - ref));
 						maxRelError = std::max(maxRelError, std::fabs((val - ref) / ref));
 					}
@@ -146,6 +150,7 @@ void printDifference(const Serializer& serializer1, const Serializer& serializer
 
 	std::cout << " | Number of values: " << std::setw(6) << nValues << "\n";
 	std::cout << " | Number of errors: " << std::setw(6) << nErrors << "\n";
+	if (nNan > 0) std::cout << " | Number of Nan errors: " << std::setw(6) << nNan << "\n";
 	std::cout << " | Percentuage of errors: " << std::setprecision(2) << std::fixed << (100.*nErrors) / nValues << " %\n";
 	std::cout << " | Maximum absolute error: " << std::setw(17) << std::setfill(' ') << std::scientific << std::setprecision(10) << maxAbsError  << "\n";
 	std::cout << " | Maximum relative error: " << std::setw(17) << std::setfill(' ') << std::scientific << std::setprecision(10) << maxRelError  << "\n";


### PR DESCRIPTION
This help to understand the result because in this case we have an error with the following max:

```
Maximum absolute error:  0.0000000000e+00
Maximum relative error:  0.0000000000e+00
```

which was a bit confusing for me at the beggining. Now it adds something like:

```
    rad_thhr
 | Number of values: 288000
 | Number of errors: 288000
 | Number of Nan errors: 288000
 | Percentuage of errors: 100.00 %
 | Maximum absolute error:  0.0000000000e+00
 | Maximum relative error:  0.0000000000e+00
```

which is more clear for the tester/programmer.
