### PR TITLE
Restore register directive type checking

### DIFF
--- a/python/pp_ser.py
+++ b/python/pp_ser.py
@@ -324,13 +324,11 @@ class pp_ser:
 
         # data type
         datatypes = dict(integer=["'int'", 'ppser_intlength'], real=['ppser_realtype', 'ppser_reallength'])
+
+        if dirs[1] not in datatypes:
+            self.__exit_error(directive = args[0], msg = 'Data type ' + dirs[1] + ' is not recognized. Valid type are "integer" and "real"')
+
         dirs[1:2] = datatypes[dirs[1]]
-        #try:
-        #    dirs[1:2] = datatypes[dirs[1]]
-        #except KeyError:
-        #    self.__exit_error(directive = args[0],
-        #                      msg = 'Data type '+dirs[1]+' is not recognized. Valid type are '
-        #                            + '"integer" and "real"')
 
         # implement some shortcuts for often recurring patterns
         if len(dirs) == 4:

--- a/python/pp_ser.py
+++ b/python/pp_ser.py
@@ -326,7 +326,7 @@ class pp_ser:
         datatypes = dict(integer=["'int'", 'ppser_intlength'], real=['ppser_realtype', 'ppser_reallength'])
 
         if dirs[1] not in datatypes:
-            self.__exit_error(directive = args[0], msg = 'Data type ' + dirs[1] + ' is not recognized. Valid type are "integer" and "real"')
+            self.__exit_error(directive = args[0], msg = 'Data type "{0}" not understood. Valid types are: {1}'.format(dirs[1], ', '.join('"' + d + '"' for d in datatypes.keys())))
 
         dirs[1:2] = datatypes[dirs[1]]
 


### PR DESCRIPTION
When using a register directive, there is an error if the given type is not valid. This error was really not clear for the user. 
I saw that some code was commented so I removed it and put another check for that problem with the correct error message. 

**Correct usage**

``` fortran
!$ser register rad_czmls3d real 1 1 ke_soil+1 1 0 0 1 0 0 0 0 0 
```

**Bad usage**

``` fortran
!$ser register rad_czmls3d 1 1 ke_soil+1 1 0 0 1 0 0 0 0 0 
```
