### PR TITLE
Return an empty list of names if there are no fields

### DIFF
--- a/python/serialbox/serialization.py
+++ b/python/serialbox/serialization.py
@@ -445,8 +445,12 @@ class serializer(object):
 
     @property
     def fieldnames(self):
-        # Get name lengths
         n_fields = fs_fields(self.serializer)
+
+        if n_fields == 0:
+            return []
+
+        # Get name lengths
         name_lengths = (ctypes.c_int*n_fields)()
         fs_fieldname_lengths(self.serializer, name_lengths)
         name_length = max(name_lengths)+1


### PR DESCRIPTION
Fixes a bug: without this change one cannot open an empty serializer and request the list of fields. Now this is possible.
