### PR TITLE
added name in end module issue with serialization

### DIFF
--- a/fortran/utils_ppser.f90
+++ b/fortran/utils_ppser.f90
@@ -138,4 +138,4 @@ FUNCTION ppser_get_mode()
 
 END FUNCTION ppser_get_mode
 
-END MODULE
+END MODULE utils_ppser


### PR DESCRIPTION
When parsing with pp_ser.py, I get an error if the module name is missing, this would fix, orhterwise need to adapt pp_ser
