### PR TITLE
Pass real type information to serialbox at init

### DIFF
--- a/doc/pp_ser/ppser_doc.tex
+++ b/doc/pp_ser/ppser_doc.tex
@@ -61,7 +61,7 @@ $ ./pp_ser.py -d . --no-prefix
 Initialize the serialization framework.
 
 \begin{lstlisting}
-!$ser init directory=dir prefix=pre [mode=] [prefix_ref=] [mpi_rank=] [rprecision=] [rperturb=] [if if_statement]
+!$ser init directory=dir prefix=pre [mode=] [prefix_ref=] [mpi_rank=] [rprecision=] [rperturb=] [realtype=] [if if_statement]
 \end{lstlisting}
 
 \begin{itemize}
@@ -72,6 +72,7 @@ Initialize the serialization framework.
 \item \texttt{mpi\_rank}: the MPI rank (optional). If the MPI rank is set, database files will be suffixed with it. 
 \item \texttt{rprecision}: specify the precision for the perturbation.
 \item \texttt{rperturb}: specify the desired magnitude of perturbation.
+\item \texttt{realtype}: specify the size of the real type with an integer value.
 \item \texttt{if\_statement}: under which condition is the directive executed
 \end{itemize}
 

--- a/fortran/utils_ppser.f90
+++ b/fortran/utils_ppser.f90
@@ -111,6 +111,12 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
       !  ... where R is a random number from -1.0 to 1.0
       zrperturb = - rperturb * rprecision
     ENDIF
+  ELSE IF ( PRESENT(rprecision) ) THEN
+    PRINT*,'Perturbation initialization not complete. rperturb is missing' 
+    CALL EXIT(1)
+  ELSE IF ( PRESENT(rperturb) ) THEN
+    PRINT*,'Perturbation initialization not complete. rprecision is missing' 
+    CALL EXIT(1)
   ENDIF
 
 END SUBROUTINE ppser_initialize

--- a/fortran/utils_ppser.f90
+++ b/fortran/utils_ppser.f90
@@ -51,16 +51,19 @@ CONTAINS
 
 !============================================================================
 
-SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprecision, rperturb)
-  CHARACTER(LEN=*), INTENT(IN)       :: directory, prefix
-  INTEGER, OPTIONAL, INTENT(IN)      :: mode
-  CHARACTER(LEN=*), OPTIONAL, INTENT(IN)     :: prefix_ref
-  REAL                               :: realvalue
-  INTEGER                            :: intvalue
-  INTEGER, OPTIONAL, INTENT(IN)      :: mpi_rank
-  REAL(KIND=8), OPTIONAL, INTENT(IN) :: rprecision, rperturb
-  CHARACTER(LEN=1), DIMENSION(128)   :: buffer
-  CHARACTER(LEN=15)                  :: suffix
+SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprecision, rperturb, realtype)
+  CHARACTER(LEN=*), INTENT(IN)           :: directory, prefix
+  INTEGER, OPTIONAL, INTENT(IN)          :: mode
+  CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: prefix_ref
+  INTEGER, OPTIONAL, INTENT(IN)          :: mpi_rank
+  REAL(KIND=8), OPTIONAL, INTENT(IN)     :: rprecision, rperturb
+  INTEGER, OPTIONAL, INTENT(IN)          :: realtype
+
+  CHARACTER(LEN=1), DIMENSION(128)       :: buffer
+  CHARACTER(LEN=15)                      :: suffix
+  REAL                                   :: realvalue
+  INTEGER                                :: intvalue
+  
 
   ! Initialize serializer and savepoint
   IF ( .NOT. ppser_initialized ) THEN
@@ -84,9 +87,9 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
 
   ! Get data size
   intvalue = 0
-  realvalue = 0.
+  realvalue = 4 ! default real type value 
   ppser_intlength = INT(SIZE(TRANSFER(intvalue, buffer)))
-  ppser_reallength = INT(SIZE(TRANSFER(realvalue, buffer)))
+  ppser_reallength = realtype
 
   ! Get name of real
   ppser_realtype = 'double'

--- a/fortran/utils_ppser.f90
+++ b/fortran/utils_ppser.f90
@@ -61,7 +61,6 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
 
   CHARACTER(LEN=1), DIMENSION(128)       :: buffer
   CHARACTER(LEN=15)                      :: suffix
-  REAL                                   :: realvalue
   INTEGER                                :: intvalue
   
 
@@ -87,9 +86,13 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
 
   ! Get data size
   intvalue = 0
-  realvalue = 4 ! default real type value 
+  IF ( PRESENT(realtype) ) THEN
+    ppser_reallength = realtype
+  ELSE
+    ppser_reallength = 4 ! Default real length
+  END IF
+
   ppser_intlength = INT(SIZE(TRANSFER(intvalue, buffer)))
-  ppser_reallength = realtype
 
   ! Get name of real
   ppser_realtype = 'double'


### PR DESCRIPTION
Get back the modification from Xavier made to support single/double precision. Taken from this branch https://github.com/lxavier/cosmo-pompa/tree/conv_tiedke_with_ser
Fix issue #61 
- add message if part of perturbation initialization is missing

@lxavier I took your changes from your branch. Can you review and merge the PR if it's fine for you ? 
