### PR TITLE
Produce USE statement at module level or PROGRAM/SUBROUTINE level

### DIFF
--- a/python/pp_ser.py
+++ b/python/pp_ser.py
@@ -638,6 +638,7 @@ class pp_ser:
             if self.__module != m.group(2):
                 self.__exit_error(msg = 'Was expecting "end '+m.group(1)+' '+self.__module+'"')
             self.__module = ''
+            self.__useStmtInModule = False
         return m
 
     def __check_intent_in(self, line):

--- a/python/pp_ser.py
+++ b/python/pp_ser.py
@@ -569,9 +569,9 @@ class pp_ser:
                 return False
             if self.__module:
                 self.__exit_error(msg = 'Unexpected ' + m.group(1) + ' statement')
+            self.__produce_use_stmt()
             if(m.group(1).upper() == 'MODULE'):
                 self.__use_stmt_in_module = True
-            self.__produce_use_stmt()
             self.__module = m.group(2)
         return m
 
@@ -691,6 +691,8 @@ class pp_ser:
 
     # Produce the USE statement and append it to l
     def __produce_use_stmt(self):
+        if (self.__use_stmt_in_module == True):
+            return
         calls_pp = [c for c in self.__calls if     c.startswith('ppser')]
         calls_fs = [c for c in self.__calls if not c.startswith('ppser')]
         ncalls = len(calls_pp) + len(calls_fs)

--- a/python/pp_ser.py
+++ b/python/pp_ser.py
@@ -561,18 +561,18 @@ class pp_ser:
 
     # LINE: module/program
     def __re_module(self):
-        r = re.compile('^ *(module|program) +([a-z][a-z0-9_]*)', re.IGNORECASE)
+        r = re.compile('^ *(?P<statement>module|program) +(?P<identifier>[a-z][a-z0-9_]*)', re.IGNORECASE)
         m = r.search(self.__line)
 
         if m:
-            if m.group(2).upper() == 'PROCEDURE':
+            if m.group('identifier').upper() == 'PROCEDURE':
                 return False
             if self.__module:
                 self.__exit_error(msg = 'Unexpected ' + m.group(1) + ' statement')
             self.__produce_use_stmt()
-            if(m.group(1).upper() == 'MODULE'):
+            if(m.group('statement').upper() == 'MODULE'):
                 self.__use_stmt_in_module = True
-            self.__module = m.group(2)
+            self.__module = m.group('identifier')
         return m
 
     # LINE: subroutine or function

--- a/python/pp_ser.py
+++ b/python/pp_ser.py
@@ -122,8 +122,6 @@ class pp_ser:
         self.__calls = set()     # calls to serialization module
         self.__outputBuffer = '' # preprocessed file
         self.__useStmtInModule = False  # USE statement was inserted in module
-        self.__implicitnone_found = False # has a implicit none statement been found?
-        self.__implicitnone_done = False # has code been inserted at IMPLICIT NONE?
 
         # define compute sign used in field definition. If one is matched,
         # the read call is not added
@@ -698,7 +696,6 @@ class pp_ser:
         if ncalls > 0:
             calls_pp += ['ppser_savepoint', 'ppser_serializer', 'ppser_serializer_ref',
                          'ppser_intlength', 'ppser_reallength', 'ppser_realtype', 'ppser_zrperturb']
-        if ncalls > 0 and not self.__implicitnone_done:
             self.__line += '\n'
             if self.ifdef:
                 self.__line += '#ifdef ' + self.ifdef + '\n'
@@ -755,9 +752,6 @@ class pp_ser:
         self.__linenum = 0       # current line number
         self.__module = ''       # current module
         self.__outputBuffer = '' # preprocessed file
-
-        self.__implicitnone_found = False # has a implicit none statement been found?
-        self.__implicitnone_done = False # has code been inserted at IMPLICIT NONE?
 
         # generate preprocessing macro for ACC_PREFIX
         if self.acc_prefix:

--- a/python/pp_ser.py
+++ b/python/pp_ser.py
@@ -121,7 +121,7 @@ class pp_ser:
         self.__module = ''       # current module
         self.__calls = set()     # calls to serialization module
         self.__outputBuffer = '' # preprocessed file
-        self.__useStmtInModule = False  # USE statement was inserted in module
+        self.__use_stmt_in_module = False  # USE statement was inserted in module
 
         # define compute sign used in field definition. If one is matched,
         # the read call is not added
@@ -570,14 +570,14 @@ class pp_ser:
             if self.__module:
                 self.__exit_error(msg = 'Unexpected ' + m.group(1) + ' statement')
             if(m.group(1).upper() == 'MODULE'):
-                self.__useStmtInModule = True
+                self.__use_stmt_in_module = True
             self.__produce_use_stmt()
             self.__module = m.group(2)
         return m
 
     # LINE: subroutine or function
     def __re_subroutine_function(self):
-        if(self.__useStmtInModule): # Statement produced at module level
+        if(self.__use_stmt_in_module): # Statement produced at module level
             return
         r = re.compile('^ *(subroutine|function).*', re.IGNORECASE)
         m = r.search(self.__line)
@@ -638,7 +638,7 @@ class pp_ser:
             if self.__module != m.group(2):
                 self.__exit_error(msg = 'Was expecting "end '+m.group(1)+' '+self.__module+'"')
             self.__module = ''
-            self.__useStmtInModule = False
+            self.__use_stmt_in_module = False
         return m
 
     def __check_intent_in(self, line):

--- a/unittest/fortran/implicit_none.f90
+++ b/unittest/fortran/implicit_none.f90
@@ -1,0 +1,24 @@
+MODULE m_ser
+
+  CONTAINS
+
+  SUBROUTINE serialize(a)
+    REAL(KIND=8), DIMENSION(:,:,:) :: a
+
+    !$ser init directory='.' prefix='SerialboxTest'
+    !$ser savepoint sp1
+    !$ser mode write
+    !$ser data ser_a=a
+
+  END SUBROUTINE serialize
+
+  SUBROUTINE dummy(a)
+    IMPLICIT NONE
+    REAL(KIND=8), DIMENSION(:,:,:) :: a
+    !$ser init directory='.' prefix='SerialboxTest'
+    !$ser savepoint sp1
+    !$ser mode write
+    !$ser data ser_a=a
+  END SUBROUTINE dummy
+
+END MODULE m_ser

--- a/unittest/fortran/no_module.f90
+++ b/unittest/fortran/no_module.f90
@@ -1,0 +1,18 @@
+program driver
+
+  integer :: ncol = 1, nlay = 42, ngpt = 256
+
+  call solver(ncol, nlay, ngpt)
+
+end program driver
+
+
+subroutine solver(ncol, nlay, ngpt)
+
+    integer   :: ncol, nlay, ngpt
+
+    !$ser init prefix='output' prefix_ref='input' directory='.'
+    !$ser mode read
+    !$ser savepoint lw_solver_input
+
+end subroutine solver


### PR DESCRIPTION
Until now, the first encountered `IMPLICIT NONE` statement was the hook to produce the serialbox `USE` statement. This leads to some bugs (see the two additional files in this PR as example). 

Now, the `USE` statement is generated at the `MODULE` level is there is a module or at each `PROGRAM` or `SUBROUTINE`/`FUNCTION` blocks. 

I'm still thinking about a way to add Fortran/`pp_ser` unit test. If anybody has a good suggestion ... Otherwise, I can add basic test with ctest for the pp_ser/fortran parsing/compilation.
