### PR TITLE
Adapt Fortran flags

### DIFF
--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -1,6 +1,16 @@
 
-if(NOT "${CMAKE_Fortran_COMPILER_ID}" MATCHES "PGI")
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp ")
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Cray")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -hnoomp -eZ")
+endif()
+
+
+if(NOT "${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp")
+endif()
+
+
+if( "${CMAKE_Fortran_COMPILER_ID}" MATCHES "PGI")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Mpreprocess")
 endif()
 
 set(


### PR DESCRIPTION
- set noomp for cray : avoid some runtime library error on kesch when linking with serialbox
- fix preprocessor flags for cray and pgi