### PR TITLE
Increase verbosity of __repr__ for savepoints

### DIFF
--- a/python/serialbox/serialization.py
+++ b/python/serialbox/serialization.py
@@ -287,7 +287,7 @@ class Savepoint(object):
         fs_destroy_savepoint(self.savepoint)
 
     def __repr__(self):
-        return '<savepoint {0}>'.format(self.name)
+        return '<savepoint {0}>'.format(str(self))
 
     def __str__(self):
         return self.name + '[ ' + ' '.join(['{0}:{1}'.format(*i) for i in self.metainfo.items()]) + ' ]'


### PR DESCRIPTION
The `__repr__` function is very useful when working within an
interactive python session. So far, the `__repr__` message for
savepoints outputs only the name of the savepoint, without any
metainformation. This commit makes it more informative by adding it,
similarly to what `__str__` does.

Example output before the merge:
```
In [5]: ser.savepoints
Out[5]: 
[<savepoint Init>,
 <savepoint Exact>,
 <savepoint StepEnd>,
 <savepoint StepEnd>,
 <savepoint StepEnd>,
 <savepoint StepEnd>,
 <savepoint End>]
```

After the merge:
```
In [3]: ser.savepoints
Out[3]: 
[<savepoint Init[  ]>,
 <savepoint Exact[ Time:0.02 ]>,
 <savepoint StepEnd[ Step:0 ]>,
 <savepoint StepEnd[ Step:1 ]>,
 <savepoint StepEnd[ Step:2 ]>,
 <savepoint StepEnd[ Step:3 ]>,
 <savepoint End[ Time:0.02 ]>]
```