### PR TITLE
Fix function `fields_at_savepoint` in Python API

### DIFF
--- a/python/serialbox/serialization.py
+++ b/python/serialbox/serialization.py
@@ -409,7 +409,7 @@ class Serializer(object):
         fs_fields_at_savepoint_name_lengths(self.serializer, savepoint.savepoint, name_lengths)
 
         names = ((ctypes.c_char_p)*n_fields)()
-        names[:] = [('\0'*name_lengths[i]).encode() for i in range(n_fields)]
+        names[:] = [('\0'*(name_lengths[i]+1)).encode() for i in range(n_fields)]
         fs_fields_at_savepoint_names(self.serializer, savepoint.savepoint, names)
 
         return [n.decode() for n in names]


### PR DESCRIPTION
A bug when calling the function `fs_fields_at_savepoint_names` was
causing the list of fields saved at a savepoint to return wrong names
and potentially to segfault.

The problem was in the allocation of space for the field names: there
was no space for the null-termination. One more character is now
allocated for each string, solving the issue.

Example output before the fix (the fields `x`, `Q` and `u` are saved at
the requested savepoint):

    In [7]: ser.fields_at_savepoint(ser.savepoints[0])
    Out[7]: ['x', 'x', 'x']

Same thing after the fix:

    In [3]: ser.fields_at_savepoint(ser.savepoints[0])
    Out[3]: ['Q', 'u', 'x']