### PR TITLE
Allow 1 to n spaces between module keyword and module name

### DIFF
--- a/python/pp_ser.py
+++ b/python/pp_ser.py
@@ -633,7 +633,7 @@ class PpSer:
 
     # LINE: end module/end program
     def __re_endmodule(self):
-        r = re.compile('^ *end *(module|program) ([a-z][a-z0-9_]*)', re.IGNORECASE)
+        r = re.compile('^ *end *(module|program) +([a-z][a-z0-9_]*)', re.IGNORECASE)
         m = r.search(self.__line)
         if m:
             if not self.__module:


### PR DESCRIPTION
Fix parsing error `Message: Unterminated module or program unit encountered` that could happen when there is more than 1 whitespaces between the `END MODULE` statements and the module name as shown below.

```fortran 
MODULE my_module
END MODULE      my_module
```