### PR TITLE
Fix Matplotlib Index Error

### DIFF
--- a/python/serialbox/Visualizer.py
+++ b/python/serialbox/Visualizer.py
@@ -106,9 +106,10 @@ class Visualizer:
     
     def _get_field(self):
         if self.plotHalo:
-            return np.rot90(self.field[:, :, self.curklevel])
+            return np.rot90(self.field[:, :, int(self.curklevel)])
         else:
-            return np.rot90(self.field[self.istart:self.iend, self.jstart:self.jend, self.curklevel])
+            return np.rot90(self.field[self.istart:self.iend, self.jstart:self.jend, int(self.curklevel)])
+
 
 
 


### PR DESCRIPTION
This fixes the error: 
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are vs